### PR TITLE
Adiciona verificacao para admin, caso seja, será liberado para poder excluir ou editar lugares previamente cadastrados

### DIFF
--- a/app/controllers/wheres_controller.rb
+++ b/app/controllers/wheres_controller.rb
@@ -1,5 +1,6 @@
 class WheresController < ApplicationController
   before_action :set_where, only: [:show, :edit, :update, :destroy]
+  before_filter :check_if_super_admin, only: [:index, :edit]
 
   def index
     @wheres = Where.all


### PR DESCRIPTION
Esse PR tem o intuito de corrigir uma falha de segurança onde qualquer pessoa sem o devido acesso ao acessar a url wheres/nome-da-cidade poderia editar ou excluir uma cidade já cadastrada